### PR TITLE
Replace PyMouse refs to PyRedactKit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,8 +13,8 @@ assignees: ''
 
 <!-- Please complete the following list of tasks, and then check it by changing the "[ ]" to "[x]" -->
 
-- [ ] I have read the [README](https://github.com/brootware/PyMouseBot/blob/main/README.md) and know the correct effect of the functional design.
-- [ ] There are no similar reports on [existing issues](https://github.com/brootware/PyMouseBot/issues?q=is%3Aissue) (including closed ones).
+- [ ] I have read the [README](https://github.com/brootware/PyRedactKit/blob/main/README.md) and know the correct effect of the functional design.
+- [ ] There are no similar reports on [existing issues](https://github.com/brootware/PyRedactKit/issues?q=is%3Aissue) (including closed ones).
 - [ ] I found the bug on the latest code of the `master` branch.
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,7 +12,7 @@ assignees: ''
 ## Checklist
 
 <!-- Please complete the following list of tasks, and then check it by changing the "[ ]" to "[x]" -->
-- [ ] There are no similar reports on [existing issues](https://github.com/brootware/PyMouseBot/issues?q=is%3Aissue) (including closed ones).
+- [ ] There are no similar reports on [existing issues](https://github.com/brootware/PyRedactKit/issues?q=is%3Aissue) (including closed ones).
 - [ ] I was in the `master` branch of the latest code.
 
 ## Is your feature request related to a problem? Please describe

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -13,8 +13,8 @@ assignees: ''
 
 <!-- Please complete the following list of tasks, and then check it by changing the "[ ]" to "[x]" -->
 
-- [ ] I have read the [README](https://github.com/brootware/PyMouseBot/blob/main/README.md) and know the correct effect of the functional design.
-- [ ] There are no similar reports on [existing issues](https://github.com/brootware/PyMouseBot/issues?q=is%3Aissue) (including closed ones).
+- [ ] I have read the [README](https://github.com/brootware/PyRedactKit/blob/main/README.md) and know the correct effect of the functional design.
+- [ ] There are no similar reports on [existing issues](https://github.com/brootware/PyRedactKit/issues?q=is%3Aissue) (including closed ones).
 - [ ] I have tried to find the answer on [Google](https://google.com/) and [StackOverflow](https://stackoverflow.com/).
 - [ ] My question is based on the latest code of the `master` branch.
 


### PR DESCRIPTION
This minor PR replaces the links on some of the issue templates from PyMouse to PyRedactKit